### PR TITLE
Made burger menu visible

### DIFF
--- a/Frontend/Landing Page/style.css
+++ b/Frontend/Landing Page/style.css
@@ -97,17 +97,33 @@ nav ul li a:hover {
 
 @media(max-width: 768px) {
   .mobile-menu-icon {
-    display: block;
+      display: block;
     cursor: pointer;
   }
 
   .bar {
+    background-color: #ffff;
     width: 25px;
     height: 3px;
     margin: 5px auto;
     transition: 0.4s;
   }
 
+                                                                .bar.mid {
+                                                                  opacity: 1;
+                                                                }
+                                
+                                                                .cross .bar:nth-child(1) {
+                                                                  transform: translateY(7.5px) rotate(45deg);
+                                                                }
+                                
+                                                                .cross .bar:nth-child(2) {
+                                                                  opacity: 0;
+                                                                }
+                                
+                                                                .cross .bar:nth-child(3) {
+                                                                  transform: translateY(-7.5px) rotate(-45deg);
+                                                                }
   .desktop-menu {
     display: none;
   }

--- a/index.html
+++ b/index.html
@@ -43,9 +43,9 @@
             <li><a class="button-link" href="./Frontend/Feature Menu/index.html">Open App</a></li>
         </ul>
         <!-- Mobile Menu Icons -->
-        <div class="mobile-menu-icon">
+        <div class="mobile-menu-icon" onclick="toggleMenu()">
             <div class="bar"></div>
-            <div class="bar"></div>
+            <div class="bar mid"></div>
             <div class="bar"></div>
         </div>
     </nav>

--- a/script.js
+++ b/script.js
@@ -44,3 +44,8 @@ window.addEventListener('scroll', function () {
         });
     }
 });
+
+function toggleMenu() {
+    const menuIcon = document.querySelector('.mobile-menu-icon');
+    menuIcon.classList.toggle('cross');
+}


### PR DESCRIPTION
The burger menu for the mobile view is visible now.

Modified the background color of divs (class="bar") to white as the previous color was similar to the navbar background color.
Also added CSS to change the 3 divs to a 2 div cross shape when clicked and back when clicked again.
Added an onclick event to the div (div class="mobile-menu-icon") which triggers a function toggleMenu() when clicked.
This function has been added that toggles between the class of the div in order to change the orientation of the 3 divs inside.

